### PR TITLE
Offers: use offer handler to respond with an BOLT 12 invoice

### DIFF
--- a/src/disk.rs
+++ b/src/disk.rs
@@ -55,7 +55,7 @@ impl Logger for FilesystemLogger {
 			.unwrap();
 	}
 }
-#[allow(dead_code)]
+
 pub(crate) fn persist_channel_peer(path: &Path, peer_info: &str) -> std::io::Result<()> {
 	let mut file = fs::OpenOptions::new().create(true).append(true).open(path)?;
 	file.write_all(format!("{}\n", peer_info).as_bytes())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -370,8 +370,6 @@ async fn handle_ldk_events(
 					hex_utils::hex_str(&counterparty_node_id.serialize()),
 				);
 			}
-			print!("> ");
-			io::stdout().flush().unwrap();
 		}
 		Event::PaymentPathSuccessful { .. } => {}
 		Event::PaymentPathFailed { .. } => {}
@@ -500,8 +498,6 @@ async fn handle_ldk_events(
 				channel_id,
 				hex_utils::hex_str(&counterparty_node_id.serialize()),
 			);
-			print!("> ");
-			io::stdout().flush().unwrap();
 		}
 		Event::ChannelReady {
 			ref channel_id,
@@ -514,8 +510,6 @@ async fn handle_ldk_events(
 				channel_id,
 				hex_utils::hex_str(&counterparty_node_id.serialize()),
 			);
-			print!("> ");
-			io::stdout().flush().unwrap();
 		}
 		Event::ChannelClosed {
 			channel_id,
@@ -530,8 +524,6 @@ async fn handle_ldk_events(
 				counterparty_node_id.map(|id| format!("{}", id)).unwrap_or("".to_owned()),
 				reason
 			);
-			print!("> ");
-			io::stdout().flush().unwrap();
 		}
 		Event::DiscardFunding { .. } => {
 			// A "real" node should probably "lock" the UTXOs spent in funding transactions until

--- a/src/node_api.rs
+++ b/src/node_api.rs
@@ -37,7 +37,7 @@ pub(crate) type Scorer = ProbabilisticScorer<Arc<NetworkGraph>, Arc<FilesystemLo
 
 pub struct Node {
 	pub(crate) logger: Arc<FilesystemLogger>,
-	pub(crate) bitcoind_client: Arc<BitcoindClient>,
+	pub bitcoind_client: Arc<BitcoindClient>,
 	pub(crate) persister: Arc<FilesystemStore>,
 	pub(crate) chain_monitor: Arc<ChainMonitor>,
 	pub(crate) keys_manager: Arc<KeysManager>,

--- a/src/node_api.rs
+++ b/src/node_api.rs
@@ -5,8 +5,8 @@ use crate::{
 	P2PGossipSyncType, PeerManagerType,
 };
 
-use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use bitcoin::Network;
+use bitcoin::secp256k1::{PublicKey, Secp256k1};
 use lightning::blinded_path::BlindedPath;
 use lightning::offers::offer::{Offer, OfferBuilder, Quantity};
 use lightning::offers::parse::Bolt12SemanticError;

--- a/src/onion.rs
+++ b/src/onion.rs
@@ -1,12 +1,22 @@
 use crate::disk::FilesystemLogger;
+use crate::ChannelManager;
+use bitcoin::hashes::sha256::Hash as Sha256;
+use bitcoin::hashes::Hash;
+use bitcoin::secp256k1::{KeyPair, PublicKey, Secp256k1};
+use core::convert::Infallible;
+use lightning::blinded_path::payment::{PaymentConstraints, ReceiveTlvs};
+use lightning::blinded_path::BlindedPath;
 use lightning::io::Read;
 use lightning::ln::msgs::DecodeError;
-use lightning::log_info;
+use lightning::ln::{PaymentHash, PaymentPreimage};
 use lightning::onion_message::{
-	CustomOnionMessageHandler, OnionMessageContents, PendingOnionMessage,
+	CustomOnionMessageHandler, OffersMessage, OffersMessageHandler, OnionMessageContents,
+	PendingOnionMessage,
 };
+use lightning::sign::KeysManager;
 use lightning::util::logger::Logger;
 use lightning::util::ser::{Writeable, Writer};
+use lightning::{log_error, log_info};
 use std::collections::VecDeque;
 use std::sync::{Arc, Mutex};
 
@@ -33,6 +43,9 @@ impl Writeable for UserOnionMessageContents {
 pub struct OnionMessageHandler {
 	pub messages: Arc<Mutex<VecDeque<UserOnionMessageContents>>>,
 	pub(crate) logger: Arc<FilesystemLogger>,
+	pub(crate) keys_manager: Arc<KeysManager>,
+	pub(crate) channel_manager: Arc<ChannelManager>,
+	pub(crate) node_id: PublicKey,
 }
 
 impl CustomOnionMessageHandler for OnionMessageHandler {
@@ -53,6 +66,78 @@ impl CustomOnionMessageHandler for OnionMessageHandler {
 	}
 
 	fn release_pending_custom_messages(&self) -> Vec<PendingOnionMessage<Self::CustomMessage>> {
+		vec![]
+	}
+}
+
+impl OffersMessageHandler for OnionMessageHandler {
+	fn handle_message(&self, message: OffersMessage) -> Option<OffersMessage> {
+		log_info!(self.logger, "Received a new offers message!");
+		match message {
+			OffersMessage::InvoiceRequest(ref invoice_request) => {
+				// Create a test preimage/secret for the payment. Since these are just for our tests
+				// the values here don't really matter that much.
+				let payment_preimage = PaymentPreimage([0; 32]);
+				let payment_hash = PaymentHash(Sha256::hash(&payment_preimage.0[..]).into_inner());
+				// TODO: Not sure if we'll need to set these None values when the payment is actually made.
+				let payment_secret = self
+					.channel_manager
+					.create_inbound_payment_for_hash(payment_hash, None, 7200, None)
+					.unwrap();
+
+				// Reminder that to keep things simple for our tests, we assume we're only connected to zero or one channel
+				// for now.
+				let chans = self.channel_manager.list_channels();
+				let htlc_minimum_msat =
+					if chans.len() == 0 { 1 } else { chans[0].inbound_htlc_minimum_msat.unwrap() };
+
+				let payee_tlvs = ReceiveTlvs {
+					payment_secret,
+					payment_constraints: PaymentConstraints {
+						max_cltv_expiry: u32::max_value(),
+						htlc_minimum_msat,
+					},
+				};
+
+				let secp_ctx = Secp256k1::new();
+				let blinded_path = BlindedPath::one_hop_for_payment(
+					self.node_id,
+					payee_tlvs,
+					&*self.keys_manager,
+					&secp_ctx,
+				)
+				.unwrap();
+
+				let secret_key = self.keys_manager.get_node_secret_key();
+				let keys = KeyPair::from_secret_key(&secp_ctx, &secret_key);
+				let pubkey = PublicKey::from(keys);
+				let wpubkey_hash =
+					bitcoin::util::key::PublicKey::new(pubkey).wpubkey_hash().unwrap();
+
+				return Some(OffersMessage::Invoice(
+					invoice_request
+						.respond_with(vec![blinded_path], payment_hash)
+						.unwrap()
+						.relative_expiry(3600)
+						//.allow_mpp()
+						.fallback_v0_p2wpkh(&wpubkey_hash)
+						.build()
+						.unwrap()
+						.sign::<_, Infallible>(|message| {
+							Ok(secp_ctx
+								.sign_schnorr_no_aux_rand(message.as_ref().as_digest(), &keys))
+						})
+						.expect("failed verifying signature"),
+				));
+			}
+			_ => {
+				log_error!(self.logger, "Unsupported offers message type");
+				return None;
+			}
+		};
+	}
+
+	fn release_pending_messages(&self) -> Vec<PendingOnionMessage<OffersMessage>> {
 		vec![]
 	}
 }


### PR DESCRIPTION
This PR:
- Adds an offer handler that allows an offer creator node to respond to an invoice request with a BOLT 12 invoice. 
- Also adds an API call for opening channel, which we'll soon need for our tests.