### PR TITLE
chore: upgrade ldk to 0.2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2018"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-lightning = { version = "0.2.0", features = ["dnssec"] }
+lightning = { version = "0.2.2", features = ["dnssec"] }
 lightning-block-sync = { version = "0.2.0", features = [ "rpc-client", "tokio" ] }
 lightning-dns-resolver = { version = "0.3.0" }
 lightning-invoice = { version = "0.34.0" }


### PR DESCRIPTION
Once #19 is through we can merge this change in as well to help prep for upgrading ldk to 0.2.2 in lndk.